### PR TITLE
Fix: ProfileInfo 컴포넌트 follow unfollow 로직 수정

### DIFF
--- a/src/components/units/profile/profileInfo/ProfileInfo.jsx
+++ b/src/components/units/profile/profileInfo/ProfileInfo.jsx
@@ -26,6 +26,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { UserContext } from "../../../../context/UserContext";
 import { customAxios } from "../../../../library/customAxios";
 export default function ProfileInfo({ userData }) {
+  const [isfollow, setIsfollow] = useState(userData.isfollow);
   const navigate = useNavigate();
   const { account } = useContext(UserContext);
   const params = useParams();
@@ -33,31 +34,24 @@ export default function ProfileInfo({ userData }) {
   function onClickButton(url) {
     navigate(url);
   }
-  const [myProfile, setMyprofile] = useState({});
+
   async function onClickFollow() {
     try {
       await customAxios.post(`profile/${userAccountname}/follow`);
-      fetchMyProfile();
-    } catch (error) {
-      console.log(error);
-    }
-  }
-  async function fetchMyProfile() {
-    const response = await customAxios.get("user/myinfo");
-    setMyprofile(response.data.user);
-  }
-  async function onClickUnfollow() {
-    try {
-      await customAxios.delete(`profile/${userAccountname}/unfollow`);
-      fetchMyProfile();
+      setIsfollow(true);
     } catch (error) {
       console.log(error);
     }
   }
 
-  useEffect(() => {
-    fetchMyProfile();
-  }, []);
+  async function onClickUnfollow() {
+    try {
+      await customAxios.delete(`profile/${userAccountname}/unfollow`);
+      setIsfollow(false);
+    } catch (error) {
+      console.log(error);
+    }
+  }
 
   return (
     <ProfileInfoWrapper>
@@ -116,11 +110,8 @@ export default function ProfileInfo({ userData }) {
               <ProfileInfoButtonIcon src={messageIcon} alt="채팅" />
             </Button>
 
-            {myProfile.following &&
-            myProfile.following.find(
-              (followingUser) => followingUser === userData._id,
-            ) ? (
-              <Button
+            {isfollow ? (
+              <Button 
                 type="button"
                 className="medium"
                 onClick={onClickUnfollow}
@@ -128,7 +119,7 @@ export default function ProfileInfo({ userData }) {
                 언팔로우
               </Button>
             ) : (
-              <Button
+              <Button style={{width:"136px"}}
                 type="button"
                 className="medium"
                 active={true}


### PR DESCRIPTION
ProfileInfo 컴포넌트 follow unfollow 로직 수정하였습니다.
기존에는 find 메소드로 일일이 확인하여 자신의 following 목록과 일치하는 유저 accoun값을 찾아 언팔로우 팔로우을 구분해주었는데 API에 isfollow(현재 내가 팔로우 한 유저인지 아닌지 를 구분) 라는 값 있어 find메소드 없이 처리하도록 로직을 수정하였습니다.
확인 부탁드립니다.