### PR TITLE
Fix: FollowerList 페이지 유저 프로필 이미지 정상적으로 출력 되지 않는 오류 수정

### DIFF
--- a/src/pages/profile/follow/followers/FollowerList.jsx
+++ b/src/pages/profile/follow/followers/FollowerList.jsx
@@ -44,8 +44,8 @@ export default function FollowerList({ follower, account }) {
         <img
           src={
             follower.image.endsWith("Ellipse.png")
-              ? follower.image
-              : defaultImage
+            ? defaultImage
+            : follower.image
           }
           onError={(e) => (e.target.src = DefaultImg)}
           alt="프로필 이미지"


### PR DESCRIPTION
 FollowerList 페이지 유저 프로필 이미지 정상적으로 출력 되지 않는 오류를 수정하였습니다.
확인 부탁드려요.